### PR TITLE
deleted useless aws processor now it is called amazon-execute-processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@
 | Amazon | [Count Spikes](https://www.fastprep.io/problems/count-spikes) | <a href="https://www.fastprep.io/problems/count-spikes"><img src="https://i.imgur.com/ojP4tYR.png" width="118" alt="Pratice"/> </a> | Aug, 31, 2023 |
 | Amazon | [Amazon Review Score](https://www.fastprep.io/problems/amazon-review-score) | <a href="https://www.fastprep.io/problems/amazon-review-score"><img src="https://i.imgur.com/ojP4tYR.png" width="118" alt="Pratice"/> </a> | Aug, 31, 2023 |
 | Amazon | [Amazon Warehouse](https://fastprep.gitbook.io/amazon-2024-oa/2023-june-aug/amazon-warehouse) | | Aug, 31, 2023 |
-| Amazon | [AWS Processors](https://fastprep.gitbook.io/amazon-2024-oa/2023-june-aug/aws-processors) |  | Aug, 31, 2023 |
 | Amazon | [Get Minimum Costs](https://www.fastprep.io/problems/get-minimum-cost) | <a href="https://www.fastprep.io/problems/get-minimum-cost"><img src="https://i.imgur.com/ojP4tYR.png" width="118" alt="Pratice"/> </a> | Aug, 31, 2023 |
 | Amazon | [Find Minimum Inefficiency](https://www.fastprep.io/problems/find-minimum-inefficiency) | <a href="https://www.fastprep.io/problems/find-minimum-inefficiency"><img src="https://i.imgur.com/ojP4tYR.png" width="118" alt="Pratice"/> </a> | Aug, 31, 2023 |
 | Amazon | [Get Average Standing](https://www.fastprep.io/problems/get-average-standing) | <a href="https://www.fastprep.io/problems/get-average-standing"><img src="https://i.imgur.com/ojP4tYR.png" width="118" alt="Pratice"/> </a> | Sep, 24, 2023 |


### PR DESCRIPTION
deleted useless aws processor now it is called amazon-execute-processes